### PR TITLE
move package.json checks to module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,10 @@ const util = require('util')
 const fs = require('fs')
 const readdir = util.promisify(fs.readdir)
 
-async function isNodeGypPackage(path) {
+async function isNodeGypPackage(path, pkg={}) {
+  const {scripts = {}, gypfile} = pkg
+  const {preinstall, install} = scripts
+  if (preinstall || install || gypfile === false) return false
   const files = await readdir(path)
   return files.some(f => /.*\.gyp$/.test(f))
 }

--- a/test/index.js
+++ b/test/index.js
@@ -15,3 +15,24 @@ tap.test('it resolves to false when there are gyp files', async t => {
   t.equal(await isNodeGypPackage(tempDir.name), false)
   tempDir.removeCallback()
 })
+
+tap.test('it resolves to false when there is a gypfile false in the package.json', async t => {
+  const tempDir = tmp.dirSync({unsafeCleanup: true})
+  fs.writeFileSync(tempDir.name + '/bindings.gyp', '')
+  t.equal(await isNodeGypPackage(tempDir.name, {gypfile: false}), false)
+  tempDir.removeCallback()
+})
+
+tap.test('it resolves to false when there is a custom install script', async t => {
+  const tempDir = tmp.dirSync({unsafeCleanup: true})
+  fs.writeFileSync(tempDir.name + '/bindings.gyp', '')
+  t.equal(await isNodeGypPackage(tempDir.name, {scripts: {install: 'echo 0'}}), false)
+  tempDir.removeCallback()
+})
+
+tap.test('it resolves to false when there is a custom preinstall script', async t => {
+  const tempDir = tmp.dirSync({unsafeCleanup: true})
+  fs.writeFileSync(tempDir.name + '/bindings.gyp', '')
+  t.equal(await isNodeGypPackage(tempDir.name, {scripts: {preinstall: 'echo 0'}}), false)
+  tempDir.removeCallback()
+})


### PR DESCRIPTION
This should be a Semver-Minor way to move the pkg.json checks into this module.

There should be a follow up to arborist + run-script to use this new feature