### PR TITLE
lib: switch to fs.promsies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 const util = require('util')
-const fs = require('fs')
-const readdir = util.promisify(fs.readdir)
+const {readdir} = require('fs').promises
 
 async function isNodeGypPackage(path) {
   const files = await readdir(path)


### PR DESCRIPTION
Currently we are calling `util.promisify` on `fs.readdir`, use official
`fs.promises` instead
