### PR TITLE
[fix] node v10.0 lacks `fs.promises`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: ['10.0', 10.x, '12.0', 12.x, '14.0', 14.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
       fail-fast: false
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const util = require('util')
-const {stat} = require('fs').promises
+const fs = require('fs')
+const {stat} = fs.promises || { stat: util.promisify(fs.stat) };
 
 async function isNodeGypPackage(path) {
   return await stat(`${path}/binding.gyp`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.1",
       "license": "ISC",
       "devDependencies": {
+        "require-inject": "^1.4.4",
         "tap": "^14.10.6",
         "tmp": "^0.2.1"
       }
@@ -356,6 +357,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "node_modules/caller": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/caller/-/caller-1.0.1.tgz",
+      "integrity": "sha1-uFGGD3Dhlds9J3OVqhp+I+ow7PU=",
+      "dev": true
+    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -393,7 +400,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1981,6 +1987,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-inject": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/require-inject/-/require-inject-1.4.4.tgz",
+      "integrity": "sha512-5Y5ctRN84+I4iOZO61gm+48tgP/6Hcd3VZydkaEM3MCuOvnHRsTJYQBOc01faI/Z9at5nsCAJVHhlfPA6Pc0Og==",
+      "dev": true,
+      "dependencies": {
+        "caller": "^1.0.1"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -2242,7 +2257,102 @@
         "tap-parser",
         "tap-yaml",
         "treport",
-        "yaml"
+        "yaml",
+        "@babel/code-frame",
+        "@babel/core",
+        "@babel/generator",
+        "@babel/helper-annotate-as-pure",
+        "@babel/helper-builder-react-jsx",
+        "@babel/helper-builder-react-jsx-experimental",
+        "@babel/helper-function-name",
+        "@babel/helper-get-function-arity",
+        "@babel/helper-member-expression-to-functions",
+        "@babel/helper-module-imports",
+        "@babel/helper-module-transforms",
+        "@babel/helper-optimise-call-expression",
+        "@babel/helper-plugin-utils",
+        "@babel/helper-replace-supers",
+        "@babel/helper-simple-access",
+        "@babel/helper-split-export-declaration",
+        "@babel/helper-validator-identifier",
+        "@babel/helpers",
+        "@babel/highlight",
+        "@babel/parser",
+        "@babel/plugin-proposal-object-rest-spread",
+        "@babel/plugin-syntax-jsx",
+        "@babel/plugin-syntax-object-rest-spread",
+        "@babel/plugin-transform-destructuring",
+        "@babel/plugin-transform-parameters",
+        "@babel/plugin-transform-react-jsx",
+        "@babel/template",
+        "@babel/traverse",
+        "@babel/types",
+        "@types/color-name",
+        "@types/prop-types",
+        "@types/yoga-layout",
+        "ansi-escapes",
+        "ansi-regex",
+        "ansi-styles",
+        "ansicolors",
+        "arrify",
+        "astral-regex",
+        "auto-bind",
+        "caller-callsite",
+        "caller-path",
+        "callsites",
+        "cardinal",
+        "chalk",
+        "ci-info",
+        "cli-cursor",
+        "cli-truncate",
+        "color-convert",
+        "color-name",
+        "convert-source-map",
+        "csstype",
+        "debug",
+        "emoji-regex",
+        "escape-string-regexp",
+        "esprima",
+        "events-to-array",
+        "gensync",
+        "globals",
+        "has-flag",
+        "is-ci",
+        "is-fullwidth-code-point",
+        "js-tokens",
+        "jsesc",
+        "json5",
+        "lodash",
+        "lodash.throttle",
+        "log-update",
+        "loose-envify",
+        "mimic-fn",
+        "minimist",
+        "ms",
+        "object-assign",
+        "onetime",
+        "path-parse",
+        "prop-types",
+        "punycode",
+        "react-is",
+        "react-reconciler",
+        "redeyed",
+        "resolve",
+        "resolve-from",
+        "restore-cursor",
+        "scheduler",
+        "semver",
+        "slice-ansi",
+        "string-length",
+        "string-width",
+        "strip-ansi",
+        "supports-color",
+        "to-fast-properties",
+        "type-fest",
+        "unicode-length",
+        "widest-line",
+        "wrap-ansi",
+        "yoga-layout-prebuilt"
       ],
       "dev": true,
       "dependencies": {
@@ -4948,6 +5058,12 @@
         }
       }
     },
+    "caller": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/caller/-/caller-1.0.1.tgz",
+      "integrity": "sha1-uFGGD3Dhlds9J3OVqhp+I+ow7PU=",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -6264,6 +6380,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
+    },
+    "require-inject": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/require-inject/-/require-inject-1.4.4.tgz",
+      "integrity": "sha512-5Y5ctRN84+I4iOZO61gm+48tgP/6Hcd3VZydkaEM3MCuOvnHRsTJYQBOc01faI/Z9at5nsCAJVHhlfPA6Pc0Og==",
+      "dev": true,
+      "requires": {
+        "caller": "^1.0.1"
+      }
     },
     "require-main-filename": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "coverage-map": "map.js"
   },
   "devDependencies": {
+    "require-inject": "^1.4.4",
     "tap": "^14.10.6",
     "tmp": "^0.2.1"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@ const tap = require('tap')
 const tmp = require('tmp')
 const fs = require('fs')
 const { isNodeGypPackage } = require('../lib')
+const requireInject = require('require-inject')
 
 tap.test('it resolves to true when there is a binding.gyp file', async t => {
   const tempDir = tmp.dirSync({unsafeCleanup: true})
@@ -21,4 +22,8 @@ tap.test('it resolves to false when there are gyp files', async t => {
   const tempDir = tmp.dirSync()
   t.equal(await isNodeGypPackage(tempDir.name), false)
   tempDir.removeCallback()
+})
+
+tap.test('it works when fs.promises is unavailable', async t => {
+  t.doesNotThrow(() => requireInject('../lib', { fs: { ...require('fs'), promises: null }}))
 })


### PR DESCRIPTION
In this node version, fall back to `util.promisify` of the callback version.

Maybe fixes https://github.com/npm/cli/issues/2623. Maybe fixes https://github.com/npm/cli/issues/2652. Maybe fixes https://github.com/npm/cli/issues/2625.