### PR TITLE
Update package.json to include the repository key

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "postversion": "npm publish",
     "prepublishOnly": "git push origin --follow-tags"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/node-gyp.git"
+  },
   "keywords": [
     "npm",
     "cli",


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	*@npmcli/node-gyp

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
### Update package.json to include the repository key

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
