### PR TITLE
fix!: align to npm 11 node engine range

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -91,20 +91,17 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 18.17.0
-          - 18.x
-          - 20.5.0
+          - 20.17.0
           - 20.x
+          - 22.9.0
           - 22.x
         exclude:
           - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.17.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 20.5.0
+            node-version: 20.17.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 20.x
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.9.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 22.x
     runs-on: ${{ matrix.platform.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,20 +67,17 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 18.17.0
-          - 18.x
-          - 20.5.0
+          - 20.17.0
           - 20.x
+          - 22.9.0
           - 22.x
         exclude:
           - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.17.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 20.5.0
+            node-version: 20.17.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 20.x
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.9.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 22.x
     runs-on: ${{ matrix.platform.os }}

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -54,7 +54,7 @@ jobs:
           else
             # strip leading slash from directory so it works as a
             # a path to the workspace flag
-            echo "workspace=-w ${dependabot_dir#/}" >> $GITHUB_OUTPUT
+            echo "workspace=--workspace ${dependabot_dir#/}" >> $GITHUB_OUTPUT
           fi
 
       - name: Apply Changes

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tap": "^16.0.1"
   },
   "engines": {
-    "node": "^18.17.0 || >=20.5.0"
+    "node": "^20.17.0 || >=22.9.0"
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",


### PR DESCRIPTION
BREAKING CHANGE: `@npmcli/node-gyp` now supports node `^20.17.0 || >=22.9.0`